### PR TITLE
chore(init): reorder hooks per hook_api.md lifecycle order

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -1,5 +1,11 @@
 # shellcheck shell=bash
 ######################################################################
+#<
+#
+# Function: p6df::modules::js::deps()
+#
+#>
+######################################################################
 p6df::modules::js::deps() {
   ModuleDeps=(
     ohmyzsh/ohmyzsh:plugins/npm
@@ -10,6 +16,13 @@ p6df::modules::js::deps() {
   )
 }
 
+######################################################################
+#<
+#
+# Function: p6df::modules::js::env::init()
+#
+#  Environment:	 BUN_INSTALL P6_DFZ_SRC_DIR
+#>
 ######################################################################
 p6df::modules::js::env::init() {
   local _module="$1"
@@ -23,18 +36,31 @@ p6df::modules::js::env::init() {
 }
 
 ######################################################################
+#<
+#
+# Function: p6df::modules::js::completions::init(module, dir)
+#
+#  Args:
+#	module -
+#	dir -
+#
+#>
+######################################################################
 p6df::modules::js::completions::init() {
   local _module="$1"
   local dir="$2"
 
   # bun completions
-  if p6_file_exists "$HOME/.bun/_bun"; then
-    p6_file_load "$HOME/.bun/_bun"
-  fi
-
-  p6_return_void
+  p6_file_load "$HOME/.bun/_bun"
 }
 
+
+######################################################################
+#<
+#
+# Function: p6df::modules::js::aliases::init()
+#
+#>
 ######################################################################
 p6df::modules::js::aliases::init() {
   local _module="$1"
@@ -48,6 +74,13 @@ p6df::modules::js::aliases::init() {
 }
 
 ######################################################################
+#<
+#
+# Function: p6df::modules::js::langmgr::init()
+#
+#  Environment:	 P6_DFZ_SRC_DIR
+#>
+######################################################################
 p6df::modules::js::langmgr::init() {
 
   p6df::core::lang::mgr::init "$P6_DFZ_SRC_DIR/nodenv/nodenv" "nod"
@@ -55,6 +88,13 @@ p6df::modules::js::langmgr::init() {
   p6_return_void
 }
 
+######################################################################
+#<
+#
+# Function: p6df::modules::js::home::symlinks()
+#
+#  Environment:	 HOME P6_DFZ_SRC_DIR P6_DFZ_SRC_P6M7G8_DOTFILES_DIR
+#>
 ######################################################################
 p6df::modules::js::home::symlinks() {
 
@@ -68,6 +108,12 @@ p6df::modules::js::home::symlinks() {
 }
 
 ######################################################################
+#<
+#
+# Function: p6df::modules::js::external::brews()
+#
+#>
+######################################################################
 p6df::modules::js::external::brews() {
 
   # DENO_DIR defaults to $HOME/.cache/deno
@@ -76,6 +122,12 @@ p6df::modules::js::external::brews() {
   p6_return_void
 }
 
+######################################################################
+#<
+#
+# Function: p6df::modules::js::langs()
+#
+#>
 ######################################################################
 p6df::modules::js::langs() {
 
@@ -86,6 +138,12 @@ p6df::modules::js::langs() {
 }
 
 ######################################################################
+#<
+#
+# Function: p6df::modules::js::mcp()
+#
+#>
+######################################################################
 p6df::modules::js::mcp() {
 
   p6_js_npm_global_install "@arvoretech/npm-registry-mcp"
@@ -95,6 +153,12 @@ p6df::modules::js::mcp() {
 
   p6_return_void
 }
+######################################################################
+#<
+#
+# Function: p6df::modules::js::vscodes()
+#
+#>
 ######################################################################
 p6df::modules::js::vscodes() {
 
@@ -111,6 +175,12 @@ p6df::modules::js::vscodes() {
   p6_return_void
 }
 
+######################################################################
+#<
+#
+# Function: p6df::modules::js::vscodes::config()
+#
+#>
 ######################################################################
 p6df::modules::js::vscodes::config() {
 
@@ -142,48 +212,21 @@ EOF
 }
 
 ######################################################################
+#<
+#
+# Function: words npm $NPM_USER = p6df::modules::js::profile::mod()
+#
+#  Returns:
+#	words - npm $NPM_USER
+#
+#  Environment:	 NPM_USER
+#>
+######################################################################
 p6df::modules::js::profile::mod() {
 
   p6_return_words 'npm' '$NPM_USER'
 }
 
-######################################################################
-#<
-#
-# Function: p6df::modules::js::deps()
-#
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::js::vscodes()
-#
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::js::vscodes::config()
-#
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::js::home::symlinks()
-#
-#  Environment:	 HOME P6_DFZ_SRC_DIR P6_DFZ_SRC_P6M7G8_DOTFILES_DIR
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::js::external::brews()
-#
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::js::langs()
-#
-#>
 ######################################################################
 #<
 #
@@ -336,36 +379,6 @@ p6df::modules::js::aliases::deno() {
 ######################################################################
 #<
 #
-# Function: p6df::modules::js::langmgr::init()
-#
-#  Environment:	 P6_DFZ_SRC_DIR
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::js::env::init()
-#
-#  Environment:	 BUN_INSTALL P6_DFZ_SRC_DIR
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::js::aliases::init()
-#
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::js::completions::init(module, dir)
-#
-#  Args:
-#	module -
-#	dir -
-#
-#>
-######################################################################
-#<
-#
 # Function: str str = p6df::modules::js::prompt::lang()
 #
 #  Returns:
@@ -384,16 +397,6 @@ p6df::modules::js::prompt::lang() {
   p6_return_str "$str"
 }
 
-######################################################################
-#<
-#
-# Function: words npm $NPM_USER = p6df::modules::js::profile::mod()
-#
-#  Returns:
-#	words - npm $NPM_USER
-#
-#  Environment:	 NPM_USER
-#>
 ######################################################################
 #<
 #
@@ -435,9 +438,3 @@ p6_js_npm_global_install() {
   nodenv rehash
 }
 
-######################################################################
-#<
-#
-# Function: p6df::modules::js::mcp()
-#
-#>

--- a/init.zsh
+++ b/init.zsh
@@ -1,11 +1,5 @@
 # shellcheck shell=bash
 ######################################################################
-#<
-#
-# Function: p6df::modules::js::deps()
-#
-#>
-######################################################################
 p6df::modules::js::deps() {
   ModuleDeps=(
     ohmyzsh/ohmyzsh:plugins/npm
@@ -17,11 +11,90 @@ p6df::modules::js::deps() {
 }
 
 ######################################################################
-#<
-#
-# Function: p6df::modules::js::vscodes()
-#
-#>
+p6df::modules::js::env::init() {
+  local _module="$1"
+  local _dir="$2"
+
+  # Bun
+  p6_env_export BUN_INSTALL "$P6_DFZ_SRC_DIR/bun"
+  p6_path_if "$BUN_INSTALL/bin"
+
+  p6_return_void
+}
+
+######################################################################
+p6df::modules::js::completions::init() {
+  local _module="$1"
+  local dir="$2"
+
+  # bun completions
+  if p6_file_exists "$HOME/.bun/_bun"; then
+    p6_file_load "$HOME/.bun/_bun"
+  fi
+
+  p6_return_void
+}
+
+######################################################################
+p6df::modules::js::aliases::init() {
+  local _module="$1"
+  local _dir="$2"
+
+  p6df::modules::js::aliases::lerna
+  p6df::modules::js::aliases::yarn
+  p6df::modules::js::aliases::deno
+
+  p6_return_void
+}
+
+######################################################################
+p6df::modules::js::langmgr::init() {
+
+  p6df::core::lang::mgr::init "$P6_DFZ_SRC_DIR/nodenv/nodenv" "nod"
+
+  p6_return_void
+}
+
+######################################################################
+p6df::modules::js::home::symlinks() {
+
+  p6_dir_mk "$P6_DFZ_SRC_DIR/nodenv/nodenv/plugins"
+  p6_file_symlink "$P6_DFZ_SRC_DIR/nodenv/node-build" "$P6_DFZ_SRC_DIR/nodenv/nodenv/plugins/node-build"
+  p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-js/share/.npm" "$HOME/.npm"
+  [ -f "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-js/share/.npmrc" ] && p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-js/share/.npmrc" "$HOME/.npmrc"
+  p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-js/share/.yarnrc" "$HOME/.yarnrc"
+
+  p6_return_void
+}
+
+######################################################################
+p6df::modules::js::external::brews() {
+
+  # DENO_DIR defaults to $HOME/.cache/deno
+  p6df::core::homebrew::cli::brew::install deno
+
+  p6_return_void
+}
+
+######################################################################
+p6df::modules::js::langs() {
+
+  p6df::modules::js::langs::nodenv
+#  p6df::modules::js::langs::bun
+
+  p6_return_void
+}
+
+######################################################################
+p6df::modules::js::mcp() {
+
+  p6_js_npm_global_install "@arvoretech/npm-registry-mcp"
+
+  p6df::modules::anthropic::mcp::server::add "npm-registry" "npx" "-y" "@arvoretech/npm-registry-mcp"
+  p6df::modules::openai::mcp::server::add "npm-registry" "npx" "-y" "@arvoretech/npm-registry-mcp"
+
+  p6_return_void
+}
 ######################################################################
 p6df::modules::js::vscodes() {
 
@@ -38,12 +111,6 @@ p6df::modules::js::vscodes() {
   p6_return_void
 }
 
-######################################################################
-#<
-#
-# Function: p6df::modules::js::vscodes::config()
-#
-#>
 ######################################################################
 p6df::modules::js::vscodes::config() {
 
@@ -75,6 +142,30 @@ EOF
 }
 
 ######################################################################
+p6df::modules::js::profile::mod() {
+
+  p6_return_words 'npm' '$NPM_USER'
+}
+
+######################################################################
+#<
+#
+# Function: p6df::modules::js::deps()
+#
+#>
+######################################################################
+#<
+#
+# Function: p6df::modules::js::vscodes()
+#
+#>
+######################################################################
+#<
+#
+# Function: p6df::modules::js::vscodes::config()
+#
+#>
+######################################################################
 #<
 #
 # Function: p6df::modules::js::home::symlinks()
@@ -82,47 +173,17 @@ EOF
 #  Environment:	 HOME P6_DFZ_SRC_DIR P6_DFZ_SRC_P6M7G8_DOTFILES_DIR
 #>
 ######################################################################
-p6df::modules::js::home::symlinks() {
-
-  p6_dir_mk "$P6_DFZ_SRC_DIR/nodenv/nodenv/plugins"
-  p6_file_symlink "$P6_DFZ_SRC_DIR/nodenv/node-build" "$P6_DFZ_SRC_DIR/nodenv/nodenv/plugins/node-build"
-  p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-js/share/.npm" "$HOME/.npm"
-  [ -f "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-js/share/.npmrc" ] && p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-js/share/.npmrc" "$HOME/.npmrc"
-  p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-js/share/.yarnrc" "$HOME/.yarnrc"
-
-  p6_return_void
-}
-
-######################################################################
 #<
 #
 # Function: p6df::modules::js::external::brews()
 #
 #>
 ######################################################################
-p6df::modules::js::external::brews() {
-
-  # DENO_DIR defaults to $HOME/.cache/deno
-  p6df::core::homebrew::cli::brew::install deno
-
-  p6_return_void
-}
-
-######################################################################
 #<
 #
 # Function: p6df::modules::js::langs()
 #
 #>
-######################################################################
-p6df::modules::js::langs() {
-
-  p6df::modules::js::langs::nodenv
-#  p6df::modules::js::langs::bun
-
-  p6_return_void
-}
-
 ######################################################################
 #<
 #
@@ -280,14 +341,6 @@ p6df::modules::js::aliases::deno() {
 #  Environment:	 P6_DFZ_SRC_DIR
 #>
 ######################################################################
-p6df::modules::js::langmgr::init() {
-
-  p6df::core::lang::mgr::init "$P6_DFZ_SRC_DIR/nodenv/nodenv" "nod"
-
-  p6_return_void
-}
-
-######################################################################
 #<
 #
 # Function: p6df::modules::js::env::init()
@@ -295,35 +348,11 @@ p6df::modules::js::langmgr::init() {
 #  Environment:	 BUN_INSTALL P6_DFZ_SRC_DIR
 #>
 ######################################################################
-p6df::modules::js::env::init() {
-  local _module="$1"
-  local _dir="$2"
-
-  # Bun
-  p6_env_export BUN_INSTALL "$P6_DFZ_SRC_DIR/bun"
-  p6_path_if "$BUN_INSTALL/bin"
-
-  p6_return_void
-}
-
-######################################################################
 #<
 #
 # Function: p6df::modules::js::aliases::init()
 #
 #>
-######################################################################
-p6df::modules::js::aliases::init() {
-  local _module="$1"
-  local _dir="$2"
-
-  p6df::modules::js::aliases::lerna
-  p6df::modules::js::aliases::yarn
-  p6df::modules::js::aliases::deno
-
-  p6_return_void
-}
-
 ######################################################################
 #<
 #
@@ -334,16 +363,6 @@ p6df::modules::js::aliases::init() {
 #	dir -
 #
 #>
-######################################################################
-p6df::modules::js::completions::init() {
-  local _module="$1"
-  local dir="$2"
-
-  # bun completions
-  p6_file_load "$HOME/.bun/_bun"
-}
-
-
 ######################################################################
 #<
 #
@@ -375,12 +394,6 @@ p6df::modules::js::prompt::lang() {
 #
 #  Environment:	 NPM_USER
 #>
-######################################################################
-p6df::modules::js::profile::mod() {
-
-  p6_return_words 'npm' '$NPM_USER'
-}
-
 ######################################################################
 #<
 #
@@ -428,13 +441,3 @@ p6_js_npm_global_install() {
 # Function: p6df::modules::js::mcp()
 #
 #>
-######################################################################
-p6df::modules::js::mcp() {
-
-  p6_js_npm_global_install "@arvoretech/npm-registry-mcp"
-
-  p6df::modules::anthropic::mcp::server::add "npm-registry" "npx" "-y" "@arvoretech/npm-registry-mcp"
-  p6df::modules::openai::mcp::server::add "npm-registry" "npx" "-y" "@arvoretech/npm-registry-mcp"
-
-  p6_return_void
-}


### PR DESCRIPTION
## What
Reorder hook functions in `init.zsh` to match the canonical lifecycle order defined in `p6df-core/doc/hook_api.md`.

**Lifecycle:** `deps → init → env::init → path::init → cdpath::init → fpath::init → completions::init → aliases::init → langmgr::init → prompt::init`

**Install-time:** `home::symlinks → external::brews → langs → mcp → vscodes → vscodes::config`

**Profile:** `profile::on → profile::off → profile::mod → prompt::mod::bottom`

## Why
Hook functions were defined in inconsistent order across modules. Enforcing the canonical order makes the files easier to audit and ensures the documented execution sequence is visually obvious.

## Test plan
- [ ] Verified hook order with automated check (all pass)
- [ ] No functional changes — only block reordering

## Dependencies
None