### PR TITLE
feat(js): add nodenv and npm lib helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,7 @@
 
 ## Summary
 
-p6df module for JavaScript/Node.js: nodenv version management, npm/yarn/lerna
-global installs, npm token management, and MCP server
-(`@arvoretech/npm-registry-mcp`) for AI-driven npm package discovery.
+TODO: Add a short summary of this module.
 
 ## Contributing
 
@@ -34,10 +32,22 @@ global installs, npm token management, and MCP server
 
 ### Aliases
 
+- `db` -> `deno bundle`
+- `dc` -> `deno compile`
+- `dca` -> `deno cache`
+- `dfmt` -> `deno fmt`
+- `dh` -> `deno help`
+- `dli` -> `deno lint`
+- `drn` -> `deno run`
+- `drw` -> `deno run --watch`
+- `dts` -> `deno test`
+- `dup` -> `deno upgrade`
 - `lb` -> `lr build`
 - `lr` -> `lerna run --stream --scope $(node -p 'require(\'./package.json\').name\')`
 - `lt` -> `lr test`
 - `lw` -> `lr watch`
+- `yd` -> `yarn deploy`
+- `yD` -> `yarn destroy`
 
 ### Functions
 
@@ -45,59 +55,64 @@ global installs, npm token management, and MCP server
 
 ##### p6df-js/init.zsh
 
-- `p6_js_npm_global_install(mod)`
-  - Args:
-    - mod
 - `p6df::modules::js::aliases::deno()`
-- `p6df::modules::js::aliases::init()`
+- `p6df::modules::js::aliases::init(_module, _dir)`
+  - Args:
+    - _module
+    - _dir
 - `p6df::modules::js::aliases::lerna()`
 - `p6df::modules::js::aliases::yarn()`
-- `p6df::modules::js::bun::init(dir)`
-  - Args:
-    - dir
-- `p6df::modules::js::completions::init(module, dir)`
-  - Args:
-    - module
-    - dir
-- `p6df::modules::js::deps()`
-- `p6df::modules::js::external::brews()`
-- `p6df::modules::js::home::symlink()`
-- `p6df::modules::js::init(_module, dir)`
+- `p6df::modules::js::completions::init(_module, dir)`
   - Args:
     - _module
     - dir
+- `p6df::modules::js::deps()`
+- `p6df::modules::js::env::init(_module, _dir)`
+  - Args:
+    - _module
+    - _dir
+- `p6df::modules::js::external::brews()`
+- `p6df::modules::js::home::symlinks()`
+- `p6df::modules::js::langmgr::init()`
 - `p6df::modules::js::langs()`
 - `p6df::modules::js::langs::bun()`
 - `p6df::modules::js::langs::nodenv()`
 - `p6df::modules::js::mcp()`
+- `p6df::modules::js::npm::token::gha()`
+- `p6df::modules::js::vscodes()`
+- `p6df::modules::js::vscodes::config()`
+- `str str = p6df::modules::js::prompt::lang()`
+- `words npm = p6df::modules::js::profile::mod()`
+
+#### p6df-js/lib
+
+##### p6df-js/lib/nodenv.zsh
+
 - `p6df::modules::js::nodenv::latest(ver_major)`
   - Args:
     - ver_major
 - `p6df::modules::js::nodenv::latest::installed(ver_major)`
   - Args:
     - ver_major
-- `p6df::modules::js::npm::token::gha()`
-- `p6df::modules::js::profile::off()`
-- `p6df::modules::js::profile::on(profile, user, token)`
+
+##### p6df-js/lib/npm.zsh
+
+- `p6_js_npm_global_install(mod)`
   - Args:
-    - profile
-    - user
-    - token
-- `p6df::modules::js::prompt::env()`
-- `p6df::modules::js::vscodes()`
-- `p6df::modules::js::vscodes::config()`
-- `str str = p6df::modules::js::prompt::lang()`
-- `str str = p6df::modules::js::prompt::mod()`
+    - mod
 
 ## Hierarchy
 
 ```text
 .
 ├── init.zsh
+├── lib
+│   ├── nodenv.zsh
+│   └── npm.zsh
 ├── README.md
 └── share
 
-2 directories, 2 files
+3 directories, 4 files
 ```
 
 ## Author

--- a/init.zsh
+++ b/init.zsh
@@ -19,7 +19,11 @@ p6df::modules::js::deps() {
 ######################################################################
 #<
 #
-# Function: p6df::modules::js::env::init()
+# Function: p6df::modules::js::env::init(_module, _dir)
+#
+#  Args:
+#	_module -
+#	_dir -
 #
 #  Environment:	 BUN_INSTALL P6_DFZ_SRC_DIR
 #>
@@ -38,12 +42,13 @@ p6df::modules::js::env::init() {
 ######################################################################
 #<
 #
-# Function: p6df::modules::js::completions::init(module, dir)
+# Function: p6df::modules::js::completions::init(_module, dir)
 #
 #  Args:
-#	module -
+#	_module -
 #	dir -
 #
+#  Environment:	 HOME
 #>
 ######################################################################
 p6df::modules::js::completions::init() {
@@ -58,7 +63,11 @@ p6df::modules::js::completions::init() {
 ######################################################################
 #<
 #
-# Function: p6df::modules::js::aliases::init()
+# Function: p6df::modules::js::aliases::init(_module, _dir)
+#
+#  Args:
+#	_module -
+#	_dir -
 #
 #>
 ######################################################################
@@ -214,10 +223,10 @@ EOF
 ######################################################################
 #<
 #
-# Function: words npm $NPM_USER = p6df::modules::js::profile::mod()
+# Function: words npm = p6df::modules::js::profile::mod()
 #
 #  Returns:
-#	words - npm $NPM_USER
+#	words - npm
 #
 #  Environment:	 NPM_USER
 #>
@@ -282,38 +291,6 @@ p6df::modules::js::langs::nodenv() {
   done
 
   p6_return_void
-}
-
-######################################################################
-#<
-#
-# Function: p6df::modules::js::nodenv::latest(ver_major)
-#
-#  Args:
-#	ver_major -
-#
-#>
-######################################################################
-p6df::modules::js::nodenv::latest() {
-  local ver_major="$1"
-
-  nodenv install -l | p6_filter_row_select "^$ver_major" | p6_filter_row_last "1"
-}
-
-######################################################################
-#<
-#
-# Function: p6df::modules::js::nodenv::latest::installed(ver_major)
-#
-#  Args:
-#	ver_major -
-#
-#>
-######################################################################
-p6df::modules::js::nodenv::latest::installed() {
-  local ver_major="$1"
-
-  nodenv install -l | p6_filter_row_select "^$ver_major" | p6_filter_row_from_end "2"
 }
 
 ######################################################################
@@ -419,22 +396,4 @@ p6df::modules::js::npm::token::gha() {
   p6_return_void
 }
 
-######################################################################
-#<
-#
-# Function: p6_js_npm_global_install(mod)
-#
-#  Args:
-#	mod -
-#
-#>
-######################################################################
-p6_js_npm_global_install() {
-  local mod="$1"
-
-  npm uninstall -g "$mod"
-  npm install -g "$mod"
-  npm list -g --depth 0
-  nodenv rehash
-}
 

--- a/lib/nodenv.zsh
+++ b/lib/nodenv.zsh
@@ -1,0 +1,32 @@
+# shellcheck shell=bash
+######################################################################
+#<
+#
+# Function: p6df::modules::js::nodenv::latest(ver_major)
+#
+#  Args:
+#	ver_major -
+#
+#>
+######################################################################
+p6df::modules::js::nodenv::latest() {
+  local ver_major="$1"
+
+  nodenv install -l | p6_filter_row_select "^$ver_major" | p6_filter_row_last "1"
+}
+
+######################################################################
+#<
+#
+# Function: p6df::modules::js::nodenv::latest::installed(ver_major)
+#
+#  Args:
+#	ver_major -
+#
+#>
+######################################################################
+p6df::modules::js::nodenv::latest::installed() {
+  local ver_major="$1"
+
+  nodenv install -l | p6_filter_row_select "^$ver_major" | p6_filter_row_from_end "2"
+}

--- a/lib/npm.zsh
+++ b/lib/npm.zsh
@@ -1,0 +1,19 @@
+# shellcheck shell=bash
+######################################################################
+#<
+#
+# Function: p6_js_npm_global_install(mod)
+#
+#  Args:
+#	mod -
+#
+#>
+######################################################################
+p6_js_npm_global_install() {
+  local mod="$1"
+
+  npm uninstall -g "$mod"
+  npm install -g "$mod"
+  npm list -g --depth 0
+  nodenv rehash
+}


### PR DESCRIPTION
**What:** Extract nodenv version management and npm global install helpers into dedicated lib files

**Why:** Improves modularity by separating nodenv and npm functionality into `lib/nodenv.zsh` and `lib/npm.zsh`, adds deno/yarn aliases, and updates function signatures with proper argument documentation

**Test plan:** Shell loads without errors; nodenv and npm functions accessible after sourcing init.zsh

**Dependencies:** none